### PR TITLE
Update isometric_projection.py

### DIFF
--- a/isometric_projection.py
+++ b/isometric_projection.py
@@ -164,7 +164,7 @@ class IsometricProjectionTools(inkex.Effect):
             transform = node.get("transform")
             # Combine our transformation matrix with any pre-existing
             # transform.
-            tr = Transform(transform) * Transform(effect_matrix)
+            tr = Transform(transform) @ Transform(effect_matrix)
 
             # Compute the location of the transformation center after applying
             # the transformation matrix.


### PR DESCRIPTION
https://inkscape.gitlab.io/extensions/documentation/_modules/inkex/deprecated/main.html#transform_mul

Plugin is complaining in the latest version that multiplying the matrix by using * is deprecated and that @ should be used