### PR TITLE
Generalize to arbitrary axes. Store metadata in svg attribute to clea…

### DIFF
--- a/dimetric_projection.inx
+++ b/dimetric_projection.inx
@@ -3,15 +3,9 @@
   <name>Dimetric Projection</name>
   <id>nl.jeroenhoek.inkscape.filter.dimetric_projection_tool</id>
   <dependency type="executable" location="extensions">axonometric_projection.py</dependency>
-  <param name="conversion" type="optiongroup" gui-text="Convert flat projection to">
-    <option value="top">Dimetric top side</option>
-    <option value="left">Dimetric left-hand side</option>
-    <option value="right">Dimetric right-hand side</option>
-  </param>
-  <param name="reverse" type="bool" gui-text="Reverse transformation">false</param>
-  <param name="orthoangle_1" type="float" precision="3" min="0" max="90" gui-text="Orthographic angle">15.000</param>
   <effect>
     <object-type>all</object-type>
+    <menu-tip>Apply dimetric transform to elements</menu-tip>
     <effects-menu>
        <submenu _name="Axonometric Projection"/>
     </effects-menu>
@@ -19,5 +13,25 @@
   <script>
     <command reldir="extensions" interpreter="python">axonometric_projection.py</command>
   </script>
+
+  <param name="projection-preset" type="string" gui-hidden="true">dimetric</param>
+  
+  <param name="mode" type="optiongroup" appearance="combo"
+          gui-text="Mode" gui-description="Apply: set the transform, Axes: change dimetric angle only, Pose: change model pose only, Remove: remove any existing iso/di/tri-metric transform">
+    <option value="apply">Apply</option>
+    <option value="update-projection">Axes</option>
+    <option value="update-model">Pose</option>
+    <option value="remove">Remove</option>
+  </param>
+
+  <param name="model-preset" type="optiongroup"
+    gui-text="Set model pose to..." gui-description="">
+    <option value="top">top side.</option>
+    <option value="left">left-hand side.</option>
+    <option value="right">right-hand side.</option>
+  </param>
+  
+  <param name="u-angle" type="float" precision="3" min="-90" max="270" appearance="full"
+    gui-text="Dimetric angle (deg)" gui-description="">-30</param>
 </inkscape-extension>
 

--- a/isometric_projection.inx
+++ b/isometric_projection.inx
@@ -3,14 +3,9 @@
   <name>Isometric Projection</name>
   <id>nl.jeroenhoek.inkscape.filter.isometric_projection_tool</id>
   <dependency type="executable" location="extensions">axonometric_projection.py</dependency>
-  <param name="conversion" type="optiongroup" gui-text="Convert flat projection to">
-    <option value="top">Isometric top side</option>
-    <option value="left">Isometric left-hand side</option>
-    <option value="right">Isometric right-hand side</option>
-  </param>
-  <param name="reverse" type="bool" gui-text="Reverse transformation">false</param>
   <effect>
     <object-type>all</object-type>
+    <menu-tip>Apply isometric transform to elements</menu-tip>
     <effects-menu>
        <submenu _name="Axonometric Projection"/>
     </effects-menu>
@@ -18,5 +13,20 @@
   <script>
     <command reldir="extensions" interpreter="python">axonometric_projection.py</command>
   </script>
+
+  <param name="projection-preset" type="string" gui-hidden="true">isometric</param>
+  
+  <param name="mode" type="optiongroup" appearance="combo"
+          gui-text="Mode" gui-description="Apply: set the transform, Remove: remove any existing iso/di/axono-metric transform">
+    <option value="apply">Apply</option>
+    <option value="remove">Remove</option>
+  </param>
+
+  <param name="model-preset" type="optiongroup"
+    gui-text="Set model pose to..." gui-description="">
+    <option value="top">top side.</option>
+    <option value="left">left-hand side.</option>
+    <option value="right">right-hand side.</option>
+  </param>
 </inkscape-extension>
 

--- a/trimetric_projection.inx
+++ b/trimetric_projection.inx
@@ -3,16 +3,9 @@
   <name>Trimetric Projection</name>
   <id>nl.jeroenhoek.inkscape.filter.trimetric_projection_tool</id>
   <dependency type="executable" location="extensions">axonometric_projection.py</dependency>
-  <param name="conversion" type="optiongroup" gui-text="Convert flat projection to">
-    <option value="top">Trimetric top side</option>
-    <option value="left">Trimetric left-hand side</option>
-    <option value="right">Trimetric right-hand side</option>
-  </param>
-  <param name="reverse" type="bool" gui-text="Reverse transformation">false</param>
-  <param name="orthoangle_1" type="float" precision="3" min="0" max="90" gui-text="Orthographic angle (left)">15.000</param>
-  <param name="orthoangle_2" type="float" precision="3" min="0" max="90" gui-text="Orthographic angle (right)">15.000</param>
   <effect>
     <object-type>all</object-type>
+    <menu-tip>Apply trimetric transform to elements</menu-tip>
     <effects-menu>
        <submenu _name="Axonometric Projection"/>
     </effects-menu>
@@ -20,5 +13,48 @@
   <script>
     <command reldir="extensions" interpreter="python">axonometric_projection.py</command>
   </script>
+
+  <param name="mode" type="optiongroup" appearance="combo"
+          gui-text="Mode" gui-description="Apply: set the transform, Axes: change axes only, Pose: change model pose only, Remove: remove any existing iso/di/tri-metric transform">
+    <option value="apply">Apply</option>
+    <option value="update-projection">Axes</option>
+    <option value="update-model">Pose</option>
+    <option value="remove">Remove</option>
+  </param>
+
+  <separator/>
+  
+  <label>Model</label>
+  <param name="model-preset" type="optiongroup" appearance="combo" gui-text="Preset"
+    gui-description="Override roll,pitch,yaw with a preset.">
+    <option value="none">None</option>
+    <option value="top">Top</option>
+    <option value="left">Left</option>
+    <option value="right">Right</option>
+  </param>
+
+  <param name="roll" type="float" precision="3" min="-180" max="180" gui-text="Roll (deg)" appearance="full">0</param>
+  <param name="pitch" type="float" precision="3" min="-180" max="180" gui-text="Pitch (deg)" appearance="full">0</param>
+  <param name="yaw" type="float" precision="3" min="-180" max="180" gui-text="Yaw (deg)" appearance="full">0</param>
+  
+  <separator/>
+  
+  <label>Axes</label>
+  <hbox>
+    <label>U axis</label>
+    <param name="u-angle" type="float" precision="3" min="-90" max="270" gui-text="Angle (deg)" appearance="full">-30</param>
+    <param name="u-scale" type="float" precision="3" min="0" max="10" gui-text="Scale">1.0</param>
+  </hbox>
+  <hbox>
+    <label>V axis</label>
+    <param name="v-angle" type="float" precision="3" min="-90" max="270" gui-text="Angle (deg)" appearance="full">90</param>
+    <param name="v-scale" type="float" precision="3" min="0" max="10" gui-text="Scale">1.0</param>
+  </hbox>
+  <hbox>
+    <label>W axis</label>
+    <param name="w-angle" type="float" precision="3" min="-90" max="270" gui-text="Angle (deg)" appearance="full">210</param>
+    <param name="w-scale" type="float" precision="3" min="0" max="10" gui-text="Scale">1.0</param>
+  </hbox>
+
 </inkscape-extension>
 


### PR DESCRIPTION
Hey mate,

I needed to use your tool to produce some technical figures, then I fell down a rabbit hole generalizing it to allow arbitrary axes and arbitrary model rotations.

I figured it would be good to clean it up and send it your way and see if you'd like to merge any of the changes. I haven't updated the docs to reflect my changes but I'd be happy to put a bit of time in to do so if you're keen.

Tested on inkscape 1.2.2.

Cheers,
Sam